### PR TITLE
kernel-module-build: use multistage build to shrink image

### DIFF
--- a/kernel-module-build/Dockerfile.template
+++ b/kernel-module-build/Dockerfile.template
@@ -1,6 +1,6 @@
-FROM balenalib/%%RESIN_MACHINE_NAME%%-debian
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:build as build
 
-RUN apt-get update && apt-get install -y curl wget build-essential libelf-dev awscli bc flex libssl-dev
+RUN install_packages curl wget build-essential libelf-dev awscli bc flex libssl-dev
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 
@@ -8,5 +8,11 @@ ARG VERSION
 
 RUN echo $VERSION
 RUN ./build.sh %%RESIN_MACHINE_NAME%% $VERSION example_module
+
+
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
+
+COPY --from=build /usr/src/app /usr/src/app
+WORKDIR /usr/src/app
 
 CMD ./run.sh


### PR DESCRIPTION
The image went from 500+MB tro ~130MB for example for the RPi3.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>