### PR TITLE
healthcheck: change restart policy for healthchecks to work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: ./site
     ports:
       - "80:8080"
-    restart: 'no'
+    restart: 'unless-stopped'
     volumes:
       - 'resin-data:/data'
   runtime-interfaces:


### PR DESCRIPTION
With restart policy "no", the unhealthy state of the service does nothing to restart. Changing to "unless-stopped" for health to take effect

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>